### PR TITLE
Fix config file error by explicitly setting path

### DIFF
--- a/GitMintty.js
+++ b/GitMintty.js
@@ -22,6 +22,7 @@ if (WScript.Arguments.Length > 0) {
 
 var cmd = quotedAbsolutePath("bin\\mintty.exe") +
 	minttyArgs +
+	" --config " + wshShell.ExpandEnvironmentStrings("%USERPROFILE%") + "/.minttyrc" +
 	" --icon " + quotedAbsolutePath("mintty\\gitmintty.ico") +
 	" --exec " + quotedAbsolutePath("bin\\sh.exe") +
 	shellArgs;


### PR DESCRIPTION
After installing, I got an error when trying to change settings about the file
`/home/<username>/.mittyrc` not being found -- well yes, Git for Windows points
the root path to its installation folder, which usually does not contain the
user's home folder on Windows.

Explicitly setting the config path to the user's home folder helps.

Note that I don't know if this expansion call quotes the path (important for
usernames with spaces, if that is possible).
