### PR TITLE
Right-click on file to get Mintty in its current folder

### DIFF
--- a/GitMintty.js
+++ b/GitMintty.js
@@ -15,7 +15,12 @@ var shellArgs = " --login -i";
 var minttyArgs = " --title \"Git Bash\"";
 
 if (WScript.Arguments.Length > 0) {
-	wshShell.CurrentDirectory = WScript.Arguments(0);
+	var argument = WScript.Arguments(0);
+	if (fso.FolderExists(argument)) {
+		wshShell.CurrentDirectory = argument;
+	} else {
+		wshShell.CurrentDirectory = fso.GetParentFolderName(argument);
+	}
 } else {
 	wshShell.CurrentDirectory = wshShell.ExpandEnvironmentStrings("%USERPROFILE%");
 }

--- a/setup.iss
+++ b/setup.iss
@@ -59,3 +59,5 @@ Source: licenses.txt; DestDir: {app}\mintty;
 [Registry]
 Root: HKCR; SubKey: Directory\shell\git_bash_mintty; ValueType: string; ValueData: "Git Bash Here (MinTTY)"; Flags: UninsDeleteKey; 
 Root: HKCR; SubKey: Directory\shell\git_bash_mintty\command; ValueType: string; ValueData: """{syswow64}\wscript.exe"" ""{app}\GitMintty.js"" ""%1"""; Flags: UninsDeleteKey; 
+Root: HKCR; SubKey: *\shell\git_bash_mintty; ValueType: string; ValueData: "Git Bash Here (MinTTY)"; Flags: UninsDeleteKey; 
+Root: HKCR; SubKey: *\shell\git_bash_mintty\command; ValueType: string; ValueData: """{syswow64}\wscript.exe"" ""{app}\GitMintty.js"" ""%1"""; Flags: UninsDeleteKey; 


### PR DESCRIPTION
Dovetails nicely with rpavlik/git-windows-mintty/issues/1 and rpavlik/git-windows-mintty/pull/3 by allowing right-clicking on a file to get a Mintty in its current folder.